### PR TITLE
Add longer EL delay (16 blocks), replace hardcoded EL service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Kurtosis devnet for running local SSV networks.
 
 ## Setup
 - Docker
-- Kurtosis
+- [Kurtosis](https://docs.kurtosis.com/install)
 - Build local client images
 
 ```bash
@@ -31,14 +31,14 @@ make run
 ```
 
 View the logs of the nodes
-```
+```bash
 kurtosis service logs -f localnet {service-name}
 ```
 
 ### Viewing currently running services
 
 ```bash
-make run
+make show
 ```
 
 

--- a/blockchain/blocks.star
+++ b/blockchain/blocks.star
@@ -1,16 +1,20 @@
-LATEST_BLOCK_NUMBER_GENERIC = "latest"
 BLOCK_NUMBER_FIELD = "block-number"
 BLOCK_HASH_FIELD = "block-hash"
 JQ_PAD_HEX_FILTER = """{} | ascii_upcase | split("") | map({{"x": 0, "0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9, "A": 10, "B": 11, "C": 12, "D": 13, "E": 14, "F": 15}}[.]) | reduce .[] as $item (0; . * 16 + $item)"""
 
-def wait_until_node_reached_block(plan, service_name, target_block_number_int):
+# Consensus client constants
+CURRENT_EPOCH_FIELD = "current-epoch"
+CURRENT_SLOT_FIELD = "current-slot"
+HEAD_SLOT_GENERIC = "head"
+
+def wait_until_node_reached_block(plan, el_service_name, target_block):
     plan.wait(
-        recipe=get_block_recipe(LATEST_BLOCK_NUMBER_GENERIC),
+        recipe=get_block_recipe("latest"),
         field="extract." + BLOCK_NUMBER_FIELD,
         assertion=">=",
-        target_value=target_block_number_int,
+        target_value=target_block,
         timeout="20m",  # Ethereum nodes can take a while to get in good shapes, especially at the beginning
-        service_name=service_name,
+        service_name=el_service_name,
     )
 
 # Constructs an rpc request to get the block receipt 
@@ -34,5 +38,27 @@ def get_block_recipe(block_number_hex):
         extract={
             BLOCK_NUMBER_FIELD: JQ_PAD_HEX_FILTER.format(".result.number"),
             BLOCK_HASH_FIELD: ".result.hash",
+        },
+    )
+
+def wait_until_node_reached_epoch(plan, cl_service_name, target_epoch):
+    plan.wait(
+        recipe=get_consensus_epoch_recipe(),
+        field="extract." + CURRENT_EPOCH_FIELD,
+        assertion=">=",
+        target_value=target_epoch,
+        timeout="20m",  # Consensus clients can take a while to sync, especially at the beginning
+        service_name=cl_service_name,
+    )
+
+
+# Constructs a REST request to get the current epoch from consensus client
+def get_consensus_epoch_recipe():
+    return GetHttpRequestRecipe(
+        port_id="http",
+        endpoint="/eth/v1/beacon/headers/" + HEAD_SLOT_GENERIC,
+        extract={
+            CURRENT_SLOT_FIELD: ".data.header.message.slot | tonumber",
+            CURRENT_EPOCH_FIELD: "(.data.header.message.slot | tonumber) / 32 | floor",  # Each epoch has 32 slots
         },
     )

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,2 +1,2 @@
-name: github.com/ssvlabs/localnet
+name: github.com/ssvlabs/ssv-mini
 description: A service for running a local Ethereum network with an SSV Node and monitoring tools.

--- a/params.yaml
+++ b/params.yaml
@@ -41,8 +41,6 @@ network:
     # 74 = 32 validators * 2(number of el/cl nodes) + 10 (running on SSV/Anchor nodes)
     # aligns with validator_count configuration under participants section
     preregistered_validator_count: 74
-    seconds_per_slot: 12
-    max_per_epoch_activation_churn_limit: 8
     # NOTE: changes the number of slots in the epoch and potentially some other network settings.
     # docs: https://github.com/ethpandaops/ethereum-package/blob/main/README.md#configuration
     # preset: minimal

--- a/utils/utils.star
+++ b/utils/utils.star
@@ -1,26 +1,22 @@
 constants = import_module("constants.star")
 
-def get_eth_urls(all_participants):
-    el_ip_addr = all_participants[
-        0
-    ].el_context.ip_addr
-    el_ws_port = all_participants[
-        0
-    ].el_context.ws_port_num
-    el_rpc_port = all_participants[
-        0
-    ].el_context.rpc_port_num
+def get_network_attributes(all_participants):
+    el_context = all_participants[0].el_context
+    el_service_name = el_context.service_name
+    el_ip_addr = el_context.ip_addr
+    el_ws_port = el_context.ws_port_num
+    el_rpc_port = el_context.rpc_port_num
+
     el_rpc_uri = "http://{0}:{1}".format(el_ip_addr, el_rpc_port)
     el_ws_uri = "ws://{0}:{1}".format(el_ip_addr, el_ws_port)
-    cl_ip_addr = all_participants[
-        0
-    ].cl_context.ip_addr
-    cl_http_port_num = all_participants[
-        0
-    ].cl_context.http_port
+
+    cl_context = all_participants[0].cl_context
+    cl_service_name = cl_context.beacon_service_name
+    cl_ip_addr = cl_context.ip_addr
+    cl_http_port_num = cl_context.http_port
     cl_uri = "http://{0}:{1}".format(cl_ip_addr, cl_http_port_num)
 
-    return (cl_uri, el_rpc_uri, el_ws_uri)
+    return (cl_service_name, cl_uri, el_service_name, el_rpc_uri, el_ws_uri)
 
 def new_template_and_data(template, template_data_json):
     return struct(template=template, data=template_data_json)


### PR DESCRIPTION
Error message that was typically occurring in SSV Node before this fix:

```
2025-06-02T08:50:51.314176Z ERROR node is not healthy {"node": "event syncer", "error": "last processed block is not set"}

2025-06-02T08:50:51.314451Z ERROR consensus_client Consensus client returned an error {"api": "NodeSyncing", "error": "failed to call GET endpoint\nGet \"[http://172.16.0.13:4000/eth/v1/node/syncing\](http://172.16.0.13:4000/eth/v1/node/syncing/)": context canceled"}

2025-06-02T08:50:51.314505Z ERROR execution_client Execution client returned an error {"method": "eth_syncing", "error": "context canceled"}

2025-06-02T08:50:51.314667Z ERROR node is not healthy {"node": "consensus client", "error": "failed to obtain node syncing status: failed to call GET endpoint\nGet \"[http://172.16.0.13:4000/eth/v1/node/syncing\](http://172.16.0.13:4000/eth/v1/node/syncing/)": context canceled"}

2025-06-02T08:50:51.314781Z ERROR node is not healthy {"node": "execution client", "error": "context canceled"}

2025-06-02T08:50:51.314888Z ERROR not all nodes are healthy
```

Also added waiting for a specific epoch (based on Yosher's feature branch). Unused for now, but may be fairly usable in the future
