### PR TITLE
Remove MEV parameters from params.yaml for now

### DIFF
--- a/params.yaml
+++ b/params.yaml
@@ -11,25 +11,6 @@ network:
   additional_services:
     - dora # Helps to see validators are working
 
-  mev_params:
-    mev_relay_image: flashbots/mev-boost-relay
-    mev_builder_image: ethpandaops/flashbots-builder:main
-    mev_builder_cl_image: sigp/lighthouse:v7.0.0
-    mev_boost_image: flashbots/mev-boost
-    mev_boost_args: []
-    mev_relay_api_extra_args: []
-    mev_relay_housekeeper_extra_args: []
-    mev_relay_website_extra_args: []
-    mev_builder_extra_args: []
-    mev_builder_prometheus_config:
-      scrape_interval: 15s
-      labels: {}
-    mev_flood_image: flashbots/mev-flood
-    mev_flood_extra_args: []
-    mev_flood_seconds_per_bundle: 15
-    custom_flood_params:
-      interval_between_transactions: 1
-
   network_params:
     # this is 'kurtosis' network ID, which is a default network. With this configuration CL /spec endpoint will return CONFIG_NAME=testnet
     network_id: "3151908"


### PR DESCRIPTION
There has been some changes in ethereum-package MEV configuration that broke our current setup. since we aren't using MEV in local testnet for now it's better to just remove it until we start using it.