### PR TITLE
fix: adjust for latest anchor & kurtosis commits + add 'prepare' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ ENCLAVE_NAME?=localnet
 default: run
 
 .PHONY: run
-run:
+run: prepare
 	kurtosis run --verbosity DETAILED --enclave ${ENCLAVE_NAME} . "$$(cat ${PARAMS_FILE})"
 
 .PHONY: reset
-reset:
+reset: prepare
 	kurtosis clean -a
 	kurtosis run --enclave ${ENCLAVE_NAME} . "$$(cat ${PARAMS_FILE})"
 
@@ -29,3 +29,29 @@ restart-ssv-nodes:
 		echo "Updating service: ssv-node-$$i"; \
 		kurtosis service update $(ENCLAVE_NAME) ssv-node-$$i; \
 	done
+
+.PHONY: prepare
+prepare:
+	@echo "⏳ Preparing requirements..."
+	@if [ ! -d "../ssv" ]; then \
+		git clone https://github.com/ssvlabs/ssv.git ../ssv; \
+	else \
+		echo "✅ ssv repo already cloned."; \
+		cd ../ssv && git fetch && git checkout stage; \
+	fi
+	@docker image inspect node/ssv >/dev/null 2>&1 || (cd ../ssv && docker build -t node/ssv . && echo "✅ SSV image built successfully.")
+	@if [ ! -d "../anchor" ]; then \
+		git clone https://github.com/sigp/anchor.git ../anchor; \
+	else \
+		echo "✅ anchor repo already cloned."; \
+		cd ../anchor && git fetch && git checkout unstable; \
+	fi
+	@docker image inspect node/anchor >/dev/null 2>&1 || (cd ../anchor && docker build -f Dockerfile.devnet -t node/anchor . && echo "✅ Anchor image built successfully.")
+	@if [ ! -d "../ethereum2-monitor" ]; then \
+		git clone https://github.com/ssvlabs/ethereum2-monitor.git ../ethereum2-monitor; \
+	else \
+		echo "✅ ethereum2-monitor repo already cloned."; \
+		cd ../ethereum2-monitor && git fetch && git checkout main; \
+	fi
+	@docker image inspect monitor >/dev/null 2>&1 || (cd ../ethereum2-monitor && docker build -t monitor . && echo "✅ Ethereum2 Monitor image built successfully.")
+	@echo "✅ All requirements are prepared, spinning up the enclave..."

--- a/generators/operator-keygen.star
+++ b/generators/operator-keygen.star
@@ -29,16 +29,16 @@ def generate_keys(plan, num_keys):
 
 # Generate a new keypair 
 def generate_operator_keys(plan, index):
-    # Custom dir path passed to anchor keygen command with arg '--data-dir' based on latest anchor commits
-    key_dir = "/usr/local/bin/"
-    
     # Execute the anchor keygen command (new output based on latest anchor commits: public_key.txt, unencrypted_private_key.txt)
     plan.exec(
         service_name=constants.ANCHOR_CLI_SERVICE_NAME,
         recipe=ExecRecipe(
-            command=["/bin/sh", "-c", "./anchor keygen --data-dir " + key_dir + " --force"],
+            command=["/bin/sh", "-c", "./anchor keygen --force"],
         ),
     )
+
+    # Read the public and private key files from the correct output directory
+    key_dir = "/root/.anchor/hoodi/"
 
     public_key_result = plan.exec(
         service_name=constants.ANCHOR_CLI_SERVICE_NAME,
@@ -50,15 +50,15 @@ def generate_operator_keys(plan, index):
     private_key_result = plan.exec(
         service_name=constants.ANCHOR_CLI_SERVICE_NAME,
         recipe=ExecRecipe(
-            command=["cat", key_dir + "private_key.txt"],
+            command=["cat", key_dir + "unencrypted_private_key.txt"],
             extract={"private": "."},
         ),
     )
 
-    # Store the private key file as the artifact
+    # Store the private key file as the artifact (for compatibility with previous usage)
     pem_artifact = plan.store_service_files(
         service_name=constants.ANCHOR_CLI_SERVICE_NAME,
-        src=key_dir + "private_key.txt",
+        src=key_dir + "unencrypted_private_key.txt",
         name="key-{}".format(index),
     )
 

--- a/params.yaml
+++ b/params.yaml
@@ -17,6 +17,7 @@ network:
     deneb_fork_epoch: 0
     electra_fork_epoch: 0
     fulu_fork_epoch: 100000000
+    perfect_peerdas_enabled: true
     
     # 74 = 32 validators * 2(number of el/cl nodes) + 10 (running on SSV/Anchor nodes)
     # aligns with validator_count configuration under participants section


### PR DESCRIPTION
- Update operator key generation to use unencrypted_private_key.txt and public_key.txt as per latest anchor changes
- Ensure compatibility with recent anchor ( [https://github.com/sigp/anchor/commit/153eab301fa09fe16aa3451ddc55dbb622894998](url) ) kurtosis commits
- Add 'prepare' make command to set up all relevant repo components for easier usage with make run and related workflows