### PR TITLE
docs: drop stale ssv-network contract-alignment TODO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,3 @@ curl -s -X POST -H "Content-Type: application/json" \
 - **Docker not running**: Start Docker Desktop / OrbStack first
 - **Stale enclave**: `make clean && make run`
 - **Resource constraints**: Docker needs 8+ CPUs, 16GB+ RAM recommended
-
-## TODO
-
-- [ ] Align SSV contracts to latest `ssvlabs/ssv-network` repo (currently using `Zacholme7/ssv-network` fork)


### PR DESCRIPTION
The CLAUDE.md TODO — "Align SSV contracts to latest `ssvlabs/ssv-network` repo (currently using `Zacholme7/ssv-network` fork)" — was resolved by #30, which replaced the `Zacholme7` foundry fork with the official `ssvlabs/ssv-network@v2.0.0` (deployed via hardhat). Removing the now-obsolete item.

Refs: #29, #30